### PR TITLE
update lib/devtools to set window size and position on initialization

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -29,8 +29,18 @@ const Devtools = module.exports = function (options) {
   log.silly('devtools: create')
 
   this.options = options || {}
+
+  // the caller make have asked us to set the window size and position
+  const chromeOptions = new chrome.Options()
+  if (this.options.width && this.options.height) {
+      chromeOptions.addArguments([`--window-size=${this.options.width},${this.options.height}`])
+  }
+  if (this.options.windowPosition) {
+      chromeOptions.addArguments([`--window-position=${this.options.windowPosition.left},${this.options.windowPosition.top}`])
+  }
+
   this.service = new chrome.ServiceBuilder(chromedriver.path).build()
-  this.driver = chrome.Driver.createSession(new chrome.Options(), this.service)
+  this.driver = chrome.Driver.createSession(chromeOptions, this.service)
 }
 
 Devtools.prototype.open = function (debuggerUrl, options) {
@@ -67,6 +77,11 @@ Devtools.prototype._resize = function () {
   log.silly('devtools: resize')
 
   const window = this.driver.manage().window()
+
+  // this may now be done on initialization, above
+  if (this.options.width && this.options.height) {
+    return window
+  }
 
   return window.getSize()
     .then((size) => window.setSize(size.width, 450))

--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -80,7 +80,7 @@ Devtools.prototype._resize = function () {
 
   // this may now be done on initialization, above
   if (this.options.width && this.options.height) {
-    return window
+    return Promise.resolve(window)
   }
 
   return window.getSize()


### PR DESCRIPTION
this avoids the flashing in the current impl, as the size is set after the window has already opened

this also adds the ability for callers to specify the window size, whereas before the height was hardwired